### PR TITLE
Fix weird Terraform bugs with Dapr config files

### DIFF
--- a/dapr.tf
+++ b/dapr.tf
@@ -23,61 +23,44 @@ resource "helm_release" "redis" {
   }
 }
 
-# -- comment out the two resources below when initially creating the cluster, somehow this fails to plan on the first run
-
-resource "kubernetes_manifest" "dapr_state_config" {
+resource "kubectl_manifest" "dapr_state_config" {
   depends_on = [kubernetes_namespace.gits]
-  manifest = {
-    "apiVersion" = "dapr.io/v1alpha1"
-    "kind"       = "Component"
-    "metadata" = {
-      "name"    = "statestore"
-      namespace = kubernetes_namespace.gits.metadata[0].name
-    }
-    "spec" = {
-      "type"    = "state.redis"
-      "version" = "v1"
+  yaml_body  = <<-EOF
+  apiVersion:  "dapr.io/v1alpha1"
+  kind: "Component"
+  metadata:
+    name: "statestore"
+    namespace: ${kubernetes_namespace.gits.metadata[0].name}
 
-      "metadata" = [
-        {
-          "name"  = "redisHost"
-          "value" = "redis-master:6379"
-        },
-        {
-          "name"  = "redisPassword"
-          "value" = random_password.redis.result
-        }
-      ]
-    }
-  }
+  spec:
+    type: "state.redis"
+    version: "v1"
+
+    metadata:
+      - name: "redisHost"
+        value: "redis-master:6379"
+      - name: "redisPassword"
+        value: ${random_password.redis.result}
+  EOF
 }
 
-
-
-resource "kubernetes_manifest" "dapr_pubsub_config" {
+resource "kubectl_manifest" "dapr_pubsub_config" {
   depends_on = [kubernetes_namespace.gits]
-  manifest = {
-    "apiVersion" = "dapr.io/v1alpha1"
-    "kind"       = "Component"
-    "metadata" = {
-      "name"    = "gits"
-      namespace = kubernetes_namespace.gits.metadata[0].name
-    }
+  yaml_body  = <<-EOF
+  apiVersion:  "dapr.io/v1alpha1"
+  kind: "Component"
+  metadata:
+    name: "gits"
+    namespace: ${kubernetes_namespace.gits.metadata[0].name}
 
-    "spec" = {
-      "type"    = "pubsub.redis"
-      "version" = "v1"
+  spec:
+    type: "pubsub.redis"
+    version: "v1"
 
-      "metadata" = [
-        {
-          "name"  = "redisHost"
-          "value" = "redis-master:6379"
-        },
-        {
-          "name"  = "redisPassword"
-          "value" = random_password.redis.result
-        }
-      ]
-    }
-  }
+    metadata:
+      - name: "redisHost"
+        value: "redis-master:6379"
+      - name: "redisPassword"
+        value: ${random_password.redis.result}
+  EOF
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14.0"
+    }
+  }
+}
+
 provider "kubernetes" {
   config_path = "./kubeconfig.yaml"
 }


### PR DESCRIPTION
The previous resource type had weird bugs and is no longer maintained, so switch to direct YAML manifests.

Note: I have been unable to test if the change works as intended as my test cluster already has Dapr installed in a different namespace
> │ Error: Unable to continue with install: ClusterRole "dapr-injector" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "gits": current value is "misarch"

However, I'm 95% sure it works regardless.